### PR TITLE
Make run_tests.py report proper exit code

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -35,9 +35,10 @@ def main(script=False):
         suite = unittest.defaultTestLoader.loadTestsFromNames(names)
 
     if script:
-        unittest.TextTestRunner(verbosity=1).run(suite)
+        result = unittest.TextTestRunner(verbosity=1).run(suite)
+        return 0 if result.wasSuccessful() else 1
     else:
         return suite
 
 if __name__ == "__main__":
-    main(True)
+    sys.exit(main(True))


### PR DESCRIPTION
Fixes: GH-15

```
$ tox -e py27
GLOB sdist-make: /Users/marca/dev/git-repos/github-cli/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/github-cli/.tox/dist/gh-cli-0.1.b.zip
py27 runtests: PYTHONHASHSEED='388081975'
py27 runtests: commands[0] | python run_tests.py
.......A valid integer is required
.E......
======================================================================
ERROR: test_format_short_issue (test_issues.TestIssueLsCommand)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/github-cli/tests/test_issues.py", line 40, in test_format_short_issue
    out = self.command.format_short_issue(self.issue)
  File "/Users/marca/dev/git-repos/github-cli/gh/commands/issue/ls.py", line 75, in format_short_issue
    return (self.fs.format(issue, bold=tc['bold'], default=tc['default'])
ValueError: Invalid conversion specification

----------------------------------------------------------------------
Ran 15 tests in 0.930s

FAILED (errors=1)
ERROR: InvocationError: '/Users/marca/dev/git-repos/github-cli/.tox/py27/bin/python run_tests.py'
___________________________________________________________________________________ summary ____________________________________________________________________________________
ERROR:   py27: commands failed
```
