### PR TITLE
Fix error in test_format_short_issue

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -37,6 +37,7 @@ class TestIssueLsCommand(BaseTest):
         self.command.repo = github3.repos.Repository(self.json('issue'))
 
     def test_format_short_issue(self):
+        self.command.fs = '#{0.number:<10} {bold}{0.title}{default} - @{0.user}'
         out = self.command.format_short_issue(self.issue)
         assert tc['default'] in out
         assert tc['bold'] in out


### PR DESCRIPTION
Fix error in `test_format_short_issue`:

```
>       return (self.fs.format(issue, bold=tc['bold'],
>       default=tc['default'])
                + extra)
E       ValueError: Invalid conversion specification

gh/commands/issue/ls.py:75: ValueError
```

by setting format string. The default format string has a `%d` in it that normally gets expanded by other code, but this doesn't happen when you call `format_short_issue` directly.

This fixes the Travis CI build which was failing before this (see https://travis-ci.org/sigmavirus24/github-cli/jobs/40092872 for example).

Fixes: GH-15
