### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/gh/base.py
+++ b/gh/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, ABCMeta
 from optparse import OptionParser
-from github3 import GitHub
+from github3 import GitHub, GitHubEnterprise
 from getpass import getpass
 from gh.util import github_config
 from gh.compat import input, ConfigParser
@@ -26,11 +26,18 @@ class Command(object):
         super(Command, self).__init__()
         assert self.name
         commands[self.name] = self
-        self.gh = GitHub()
+        self.gh = self.get_github()
         self.gh.set_user_agent('github-cli/{0} (http://git.io/MEmEmw)'.format(
             __version__
         ))
         self.parser = CustomOptionParser(usage=self.usage)
+
+    def get_github(self):
+        gh_cli_url = os.getenv('GH_CLI_URL')
+        if gh_cli_url:
+            return GitHubEnterprise(gh_cli_url)
+        else:
+            return GitHub()
 
     @abstractmethod
     def run(self, options, args):

--- a/gh/base.py
+++ b/gh/base.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABCMeta
 from optparse import OptionParser
 from github3 import GitHub, GitHubEnterprise
+from github3.models import urlparse
 from getpass import getpass
 from gh.util import github_config
 from gh.compat import input, ConfigParser
@@ -61,10 +62,14 @@ class Command(object):
         config = github_config()
         parser = ConfigParser()
 
+        section = 'github'
+        if hasattr(self.gh, 'url'):
+            section += ':' + urlparse(self.gh.url).netloc
+
         # Check to make sure the file exists and we are allowed to read it
         if os.path.isfile(config) and os.access(config, os.R_OK | os.W_OK):
             parser.readfp(open(config))
-            self.gh.login(token=parser.get('github', 'token'))
+            self.gh.login(token=parser.get(section, 'token'))
         else:
         # Either the file didn't exist or we didn't have the correct
         # permissions


### PR DESCRIPTION
To use it, set the GH_CLI_URL environment variable -- e.g.:

```
export GH_CLI_URL='https://github.mycompany.com'
```

This allows me to use `gh` with our GitHub Enterprise server -- e.g.:

```
$ gh -r devmonkeys/smstack issue.ls | head -n 2
#257  Add gui - @sontek
#254  Make it fast - @georges
```

Even after adding the URL, it was a pain to switch back and forth between GitHub Enterprise and public GitHub, because there is only one `~/.githubconfig` file with one `[github]` section to store the token. Thus in ee9b551, I added the ability to store tokens for multiple servers -- e.g.:

```
[github]
token = 65f6...

[github:github.mycompany.com]
token = 16a3...
```

Note: This PR depends on https://github.com/sigmavirus24/github3.py/pull/301; it won't work without that.
