### PR TITLE
Fix broken repo.* commands

### DIFF
--- a/gh/commands/repo/create.py
+++ b/gh/commands/repo/create.py
@@ -3,7 +3,7 @@ from gh.compat import input
 
 
 class CreateRepoCommand(Command):
-    name = 'create.repo'
+    name = 'repo.create'
     usage = '%prog [options] create.repo [options] name'
     summary = 'Create a new repository'
     subcommands = {}

--- a/gh/commands/repo/fork.py
+++ b/gh/commands/repo/fork.py
@@ -2,7 +2,7 @@ from gh.base import Command
 
 
 class ForkRepoCommand(Command):
-    name = 'fork.repo'
+    name = 'repo.fork'
     usage = '%prog [options] fork.repo [options] login/repo'
     summary = 'Fork a repository'
     subcommands = {}

--- a/gh/commands/repo/repos.py
+++ b/gh/commands/repo/repos.py
@@ -4,7 +4,7 @@ from github3.users import User
 
 
 class ReposCommand(Command):
-    name = 'repos'
+    name = 'repo.repos'
     usage = ('%prog [options] repos [options] [login] [sub-command]')
     summary = ('Interact with the Repositories API')
     fs = ("{d[bold]}{0.name}{d[default]}\n  {1:.72}")
@@ -64,9 +64,9 @@ class ReposCommand(Command):
         }
 
         if isinstance(user, User):
-            repos = self.gh.iter_repos(**kwargs)
-        else:
             repos = self.gh.iter_repos(self.user, **kwargs)
+        else:
+            repos = self.gh.iter_repos(**kwargs)
 
         for repo in repos:
             fs = self.fs if repo.description else self.fs2

--- a/gh/commands/repo/repos.py
+++ b/gh/commands/repo/repos.py
@@ -69,8 +69,13 @@ class ReposCommand(Command):
             repos = self.gh.iter_repos(**kwargs)
 
         for repo in repos:
-            fs = self.fs if repo.description else self.fs2
-            print(fs.format(repo, repo.description.encode('utf-8'), d=tc))
+            if repo.description:
+                fs = self.fs
+                description = repo.description.encode('utf-8')
+            else:
+                fs = self.fs2
+                description = None
+            print(fs.format(repo, description, d=tc))
 
         return self.SUCCESS
 

--- a/gh/commands/repo/star.py
+++ b/gh/commands/repo/star.py
@@ -2,7 +2,7 @@ from gh.base import Command
 
 
 class StarRepoCommand(Command):
-    name = 'star.repo'
+    name = 'repo.star'
     usage = '%prog [options] star.repo [login/]repo'
     summary = 'Star a repository'
     subcommands = {}


### PR DESCRIPTION
This fixed busted `repo.*` commands.

Two big changes:
1. Add `gh/commands/repo/__init__.py` so that `gh.commands.repo` is a package and `import`able.
2. Change the command names to be `repo.foo` instead of `foo.repo`.
